### PR TITLE
feat: Add GoogleTagManager script and contexts

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -32,6 +32,8 @@ const routes: Routes = [
 ];
 
 @NgModule({
+  // NOTE: Remember to change GoogleTagManager history triggers if we decide to drop
+  // the url 'useHash' strategy.
   imports: [RouterModule.forRoot(routes, { useHash: true })],
   exports: [RouterModule]
 })

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,10 +1,10 @@
-import {Component, ViewChild} from '@angular/core';
-
+import {Component, Inject, Renderer2, ViewChild} from '@angular/core';
+import {DOCUMENT} from '@angular/common';
 import {Observable} from 'rxjs';
-
+import {environment} from '@environment';
 import {RouterExtensionsService} from '@shared/services/router-extensions.service';
+import {renderGTMInitScript} from './modules/shared/google-tag-manager/gtm-script';
 import {routeFader} from './routeFader.animation';
-
 
 @Component({
   selector: 'app-root',
@@ -13,12 +13,19 @@ import {routeFader} from './routeFader.animation';
   animations: [routeFader]
 })
 export class AppComponent {
-  title = 'ekostraz';
   isRouteLoading$: Observable<boolean>;
 
   @ViewChild('sidenav', {static: true}) sidenav;
 
-  constructor(routerExtensions: RouterExtensionsService) {
+  constructor(
+      routerExtensions: RouterExtensionsService,
+      renderer2: Renderer2,
+      @Inject(DOCUMENT) document,
+  ) {
     this.isRouteLoading$ = routerExtensions.isRouteLoading$;
+
+    if (environment.useGoogleTagManager) {
+      renderGTMInitScript(renderer2, document.body);
+    }
   }
 }

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -9,7 +9,8 @@ import { environment } from '@environment';
 import { AuthModule } from './modules/auth/auth.module';
 import { AppRoutingModule } from './app-routing.module';
 import { NavModule } from './modules/nav/nav.module';
-import { PublicFormModule} from './modules/public-form/public-form.module';
+import { PublicFormModule } from './modules/public-form/public-form.module';
+import { SharedModule } from './modules/shared/shared.module';
 
 import { AppComponent } from './app.component';
 import { HomePageComponent } from './home-page/home-page.component';
@@ -33,7 +34,7 @@ import { EKOSTRAZ_GTM_CONTEXTS } from './ekostraz-gtm-contexts';
     MatProgressBarModule,
     NavModule,
     PublicFormModule,
-    HttpClientModule,
+    SharedModule,
   ],
   providers: [
     {provide: LOCALE_ID, useFactory: localeProviderFactory},

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -13,7 +13,7 @@ import { AppComponent } from './app.component';
 import { HomePageComponent } from './home-page/home-page.component';
 
 import { errorHandlerFactory, localeProviderFactory } from './providerFactories';
-import { environment } from '../environments/environment';
+import { environment } from '@environment';
 
 @NgModule({
   declarations: [

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -4,6 +4,8 @@ import { HttpClientModule } from '@angular/common/http';
 import { MatButtonModule, MatProgressBarModule} from '@angular/material';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
+import { environment } from '@environment';
+
 import { AuthModule } from './modules/auth/auth.module';
 import { AppRoutingModule } from './app-routing.module';
 import { NavModule } from './modules/nav/nav.module';
@@ -13,7 +15,8 @@ import { AppComponent } from './app.component';
 import { HomePageComponent } from './home-page/home-page.component';
 
 import { errorHandlerFactory, localeProviderFactory } from './providerFactories';
-import { environment } from '@environment';
+import { GTM_CONTEXTS } from './modules/shared/google-tag-manager/gtm-contexts';
+import { EKOSTRAZ_GTM_CONTEXTS } from './ekostraz-gtm-contexts';
 
 @NgModule({
   declarations: [
@@ -25,6 +28,7 @@ import { environment } from '@environment';
     AppRoutingModule,
     BrowserModule,
     BrowserAnimationsModule,
+    HttpClientModule,
     MatButtonModule,
     MatProgressBarModule,
     NavModule,
@@ -33,7 +37,8 @@ import { environment } from '@environment';
   ],
   providers: [
     {provide: LOCALE_ID, useFactory: localeProviderFactory},
-    {provide: ErrorHandler, useFactory: errorHandlerFactory(environment.useSentry, environment.sentryDSN)}
+    {provide: GTM_CONTEXTS, useValue: EKOSTRAZ_GTM_CONTEXTS},
+    {provide: ErrorHandler, useFactory: errorHandlerFactory(environment.useSentry, environment.sentryDSN)},
   ],
   bootstrap: [AppComponent]
 })

--- a/frontend/src/app/ekostraz-gtm-contexts.ts
+++ b/frontend/src/app/ekostraz-gtm-contexts.ts
@@ -1,0 +1,12 @@
+export const EKOSTRAZ_GTM_CONTEXTS: {[key: string]: string} = {
+    desktopNav: 'desktop-nav',
+    mobileNav: 'mobile-nav',
+    hamburgerMenuButton: 'hamburger-menu-button',
+    homePage: 'home-page',
+    interventionList: 'intervention-list',
+    interventionDetails: 'intervention-details',
+    interventionMap: 'intervention-map',
+    publicInterventionForm: 'intervention-form-public',
+    privateInterventionForm: 'intervention-form-private',
+    loginDialog: 'login-dialog', // TODO: Add tags after login is finished
+};

--- a/frontend/src/app/home-page/home-page.component.html
+++ b/frontend/src/app/home-page/home-page.component.html
@@ -1,4 +1,4 @@
-<section class='HomePage'>
+<section class='HomePage' [withGtmContext]="homePageGtmContext">
     <div class="logo-container"></div>
     <button routerLink='/zglos-interwencje' color="primary" mat-raised-button>Zgłoś interwencję</button>
 </section>

--- a/frontend/src/app/home-page/home-page.component.ts
+++ b/frontend/src/app/home-page/home-page.component.ts
@@ -1,8 +1,15 @@
-import { Component } from '@angular/core';
+import {Component, Inject} from '@angular/core';
+import {GTM_CONTEXTS} from '../modules/shared/google-tag-manager/gtm-contexts';
 
 @Component({
   selector: 'app-home-page',
   templateUrl: './home-page.component.html',
   styleUrls: ['./home-page.component.scss']
 })
-export class HomePageComponent { }
+export class HomePageComponent {
+  homePageGtmContext: string;
+
+  constructor(@Inject(GTM_CONTEXTS) gtmContexts) {
+    this.homePageGtmContext = gtmContexts.homePage;
+  }
+}

--- a/frontend/src/app/modules/auth/auth.module.ts
+++ b/frontend/src/app/modules/auth/auth.module.ts
@@ -2,6 +2,8 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {MatButtonModule, MatDialogModule} from '@angular/material';
 
+import {SharedModule} from '../shared/shared.module';
+
 import { LoginComponent } from './login/login.component';
 import {AuthService} from './auth.service';
 
@@ -11,6 +13,7 @@ import {AuthService} from './auth.service';
     CommonModule,
     MatButtonModule,
     MatDialogModule,
+    SharedModule,
   ],
   exports: [LoginComponent],
   providers: [AuthService]

--- a/frontend/src/app/modules/auth/login/login.component.html
+++ b/frontend/src/app/modules/auth/login/login.component.html
@@ -1,9 +1,9 @@
 <ng-template #dialogTemplate>
     <h2 mat-dialog-title>Zaloguj się</h2>
-    <mat-dialog-content class="mat-typography">
+    <mat-dialog-content class="mat-typography" [withGtmContext]="loginDialogGtmContext">
         TODO: Tutaj będzie formularz lub trzeba zrobic social login etc.
     </mat-dialog-content>
-    <mat-dialog-actions align="center">
+    <mat-dialog-actions align="center" [withGtmContext]="loginDialogGtmContext">
         <button mat-button
                 (click)="onLoginClick()"
                 color='primary'

--- a/frontend/src/app/modules/auth/login/login.component.ts
+++ b/frontend/src/app/modules/auth/login/login.component.ts
@@ -1,7 +1,8 @@
-import {Component, OnInit, TemplateRef, ViewChild, ViewEncapsulation} from '@angular/core';
+import {Component, Inject, OnInit, TemplateRef, ViewChild, ViewEncapsulation} from '@angular/core';
 import {MatDialog, MatDialogRef} from '@angular/material';
 import {ComponentWithSubscriptions} from '@shared/base';
 import {AuthService} from '../auth.service';
+import {GTM_CONTEXTS} from '../../shared/google-tag-manager/gtm-contexts';
 
 const DIALOG_BACKDROP_CLASS = 'login-dialog-backdrop';
 const DIALOG_PANEL_CLASS = 'login-dialog-panel';
@@ -16,9 +17,15 @@ const DIALOG_PANEL_CLASS = 'login-dialog-panel';
 export class LoginComponent extends ComponentWithSubscriptions implements OnInit {
   @ViewChild('dialogTemplate', {static: true}) dialogTemplate: TemplateRef<any>;
   dialog: MatDialogRef<any>;
+  loginDialogGtmContext: string;
 
-  constructor(private dialogService: MatDialog, private authService: AuthService) {
+  constructor(
+      private dialogService: MatDialog,
+      private authService: AuthService,
+      @Inject(GTM_CONTEXTS) gtmContexts,
+  ) {
     super();
+    this.loginDialogGtmContext = gtmContexts.loginDialog;
   }
 
   ngOnInit() {

--- a/frontend/src/app/modules/intervention-form/form/form.component.html
+++ b/frontend/src/app/modules/intervention-form/form/form.component.html
@@ -2,8 +2,12 @@
     <mat-card-title>{{formTitle}}</mat-card-title>
 
     <mat-card-content>
-        <form [formGroup]='interventionForm' (ngSubmit)="onSubmit(interventionForm.value)">
+        <form [formGroup]='interventionForm'
+              (ngSubmit)="onSubmit(interventionForm.value)"
+              [withGtmContext]="interventionFormGtmContext">
+
             <input type="text" hidden formControlName="id" />
+
             <mat-form-field *ngIf='inPrivateMode && intervention'>
                 <input type='text' formControlName="date" matInput placeholder="Data utworzenia" />
             </mat-form-field>

--- a/frontend/src/app/modules/intervention-form/form/form.component.ts
+++ b/frontend/src/app/modules/intervention-form/form/form.component.ts
@@ -1,8 +1,9 @@
-import {ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {ChangeDetectionStrategy, Component, EventEmitter, Inject, Input, OnInit, Output} from '@angular/core';
 import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 
 import {InterventionStatus} from '@shared/intervention.status';
 import {InterventionFormData} from '../types';
+import {GTM_CONTEXTS} from '../../shared/google-tag-manager/gtm-contexts';
 
 
 const interventionStatuses = [
@@ -42,21 +43,27 @@ export class InterventionFormComponent implements OnInit {
   @Input() buttonText = 'Wyślij zgłoszenie';
   /** Intervention data to fill the form with. */
   @Input() intervention: InterventionFormData | null = null;
-
-  /** Event emitted on form submit */
   @Output() formSubmit = new EventEmitter<InterventionFormData>();
-
-  /** Intervention status value map used for select input generation */
   interventionStatuses = interventionStatuses;
-  /** Main form component displayed on the screen */
   interventionForm = this.buildForm();
+  interventionFormGtmContext: string;
 
-  constructor(private formBuilder: FormBuilder) {}
+  constructor(private formBuilder: FormBuilder, @Inject(GTM_CONTEXTS) private gtmContexts) {}
 
   ngOnInit() {
+    this.initGtmContext();
+    this.maybePatchFormValue();
+  }
+
+  private maybePatchFormValue() {
     if (this.intervention) {
       this.interventionForm.patchValue(this.intervention);
     }
+  }
+
+  private initGtmContext() {
+    this.interventionFormGtmContext =
+        this.inPrivateMode ? this.gtmContexts.privateInterventionForm : this.gtmContexts.publicInterventionForm;
   }
 
   private buildForm(): FormGroup {

--- a/frontend/src/app/modules/intervention-form/intervention-form.module.ts
+++ b/frontend/src/app/modules/intervention-form/intervention-form.module.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/material';
 
 import {InterventionFormComponent} from './form/form.component';
+import {SharedModule} from '../shared/shared.module';
 
 @NgModule({
     declarations: [InterventionFormComponent],
@@ -21,6 +22,7 @@ import {InterventionFormComponent} from './form/form.component';
         MatFormFieldModule,
         MatInputModule,
         MatSelectModule,
+        SharedModule,
     ],
     exports: [InterventionFormComponent],
 })

--- a/frontend/src/app/modules/interventions/details/delete.dialog.ts
+++ b/frontend/src/app/modules/interventions/details/delete.dialog.ts
@@ -3,14 +3,17 @@ import { Component } from '@angular/core';
 @Component({
     selector: 'app-delete-intervention-dialog',
     template: `
-        <h2 mat-dialog-title>Usuń zgłoszenie</h2>
+        <h2 mat-dialog-title>{{title}}</h2>
         <mat-dialog-content class="mat-typography">
             Czy jesteś pewien, że chcesz usunąć to zgłoszenie?
         </mat-dialog-content>
         <mat-dialog-actions align="end">
-            <button mat-button mat-dialog-close cdkFocusInitial>Nie</button>
-            <button mat-button [mat-dialog-close]="true">Tak</button>
+            <button mat-button mat-dialog-close cdkFocusInitial withGtmContext [gtmData]="gtmDialogData">Nie</button>
+            <button mat-button [mat-dialog-close]="true" withGtmContext [gtmData]="gtmDialogData">Tak</button>
         </mat-dialog-actions>
     `,
 })
-export class DeleteDialog { }
+export class DeleteDialog {
+    title = 'Usuń zgłoszenie';
+    gtmDialogData = {dialogTitle: this.title};
+}

--- a/frontend/src/app/modules/interventions/details/details.component.html
+++ b/frontend/src/app/modules/interventions/details/details.component.html
@@ -1,4 +1,5 @@
 <mat-card *ngIf="intervention"
+          [withGtmContext]="interventionDetailsGtmContext"
           [ngClass]="{'mat-elevation-z4': !embedded, 'embedded': !!embedded}">
 
     <div class="title-wrapper">

--- a/frontend/src/app/modules/interventions/details/details.component.ts
+++ b/frontend/src/app/modules/interventions/details/details.component.ts
@@ -1,10 +1,11 @@
-import { Component, Input } from '@angular/core';
+import {Component, Inject, Input} from '@angular/core';
 import { Router } from '@angular/router';
 import { Intervention, InterventionRouterState } from '../types';
 import { MatDialog } from '@angular/material/dialog';
 import { DeleteDialog } from './delete.dialog';
 import { InterventionsService } from '../interventions.service';
 import { ComponentWithSubscriptions } from '@shared/base';
+import {GTM_CONTEXTS} from '../../shared/google-tag-manager/gtm-contexts';
 
 @Component({
   selector: 'app-intervention-details',
@@ -14,9 +15,16 @@ import { ComponentWithSubscriptions } from '@shared/base';
 export class DetailsComponent extends ComponentWithSubscriptions {
   @Input() intervention: Intervention;
   @Input() embedded?: boolean;
+  interventionDetailsGtmContext: string;
 
-  constructor(private router: Router, private dialog: MatDialog, private interventionService: InterventionsService) {
+  constructor(
+      private router: Router,
+      private dialog: MatDialog,
+      private interventionService: InterventionsService,
+      @Inject(GTM_CONTEXTS) gtmContexts,
+  ) {
     super();
+    this.interventionDetailsGtmContext = gtmContexts.interventionDetails;
   }
 
   showDeleteDialog() {

--- a/frontend/src/app/modules/interventions/list/list.component.html
+++ b/frontend/src/app/modules/interventions/list/list.component.html
@@ -1,4 +1,4 @@
-<section class="InterventionsList">
+<section class="InterventionsList" [withGtmContext]="interventionsListGtmContext">
     <h1 class="mat-h1">Lista interwencji</h1>
     <button (click)='showMap()' color="primary" mat-raised-button [disabled]="!initialData">
         Sprawdź na mapie!

--- a/frontend/src/app/modules/interventions/list/list.component.ts
+++ b/frontend/src/app/modules/interventions/list/list.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectorRef, Component} from '@angular/core';
+import {ChangeDetectorRef, Component, Inject} from '@angular/core';
 import {Router} from '@angular/router';
 
 import {Observable} from 'rxjs';
@@ -7,6 +7,7 @@ import {map} from 'rxjs/operators';
 import {LoadingComponent} from '@shared/base';
 import {Intervention, InterventionListRouterState, ListIntervention} from '../types';
 import {InterventionsService} from '../interventions.service';
+import {GTM_CONTEXTS} from '../../shared/google-tag-manager/gtm-contexts';
 
 
 @Component({
@@ -15,15 +16,19 @@ import {InterventionsService} from '../interventions.service';
   styleUrls: ['./list.component.scss']
 })
 export class ListComponent extends LoadingComponent<ListIntervention[]> {
+  interventionsListGtmContext: string;
+
   constructor(private router: Router,
               private interventionsService: InterventionsService,
+              @Inject(GTM_CONTEXTS) gtmContexts,
               changeDetector: ChangeDetectorRef) {
     super(changeDetector);
+    this.interventionsListGtmContext = gtmContexts.interventionList;
   }
 
   getInitialData$(): Observable<ListIntervention[]> {
      return this.interventionsService.fetchInterventions().pipe(
-         map(interventions => mapToTableData(interventions))
+         map(toTableData)
      );
   }
 
@@ -34,6 +39,6 @@ export class ListComponent extends LoadingComponent<ListIntervention[]> {
   }
 }
 
-function mapToTableData(interventions: Intervention[]): ListIntervention[] {
+function toTableData(interventions: Intervention[]): ListIntervention[] {
   return interventions.map((intervention, index) => ({...intervention, position: index + 1}));
 }

--- a/frontend/src/app/modules/interventions/map/map.component.html
+++ b/frontend/src/app/modules/interventions/map/map.component.html
@@ -2,6 +2,7 @@
             [loaderText]="'Ładowanie mapy...'"
             [renderHiddenBeforeLoaded]="true">
     <agm-map *ngIf="initialData"
+             [withGtmContext]="interventionMap"
              [latitude]="initialData[0].geoLat"
              [longitude]="initialData[0].geoLng"
              (tilesLoaded)="onTilesLoaded()">

--- a/frontend/src/app/modules/interventions/map/map.component.ts
+++ b/frontend/src/app/modules/interventions/map/map.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectorRef, Component} from '@angular/core';
+import {ChangeDetectorRef, Component, Inject} from '@angular/core';
 import {LoadingComponent} from '@shared/base';
 
 import {Subject} from 'rxjs';
@@ -6,6 +6,7 @@ import {take} from 'rxjs/operators';
 
 import {Intervention} from '../types';
 import {InterventionsService} from '../interventions.service';
+import {GTM_CONTEXTS} from '../../shared/google-tag-manager/gtm-contexts';
 
 @Component({
   selector: 'app-interventions-map',
@@ -15,9 +16,15 @@ import {InterventionsService} from '../interventions.service';
 export class MapComponent extends LoadingComponent<Intervention[]> {
   tilesLoadedSubject = new Subject();
   afterDataLoaded$ = this.tilesLoadedSubject.asObservable().pipe(take(1));
+  interventionMap: string;
 
-  constructor(private interventionsService: InterventionsService, changeDetector: ChangeDetectorRef) {
+  constructor(
+      private interventionsService: InterventionsService,
+      changeDetector: ChangeDetectorRef,
+      @Inject(GTM_CONTEXTS) gtmContexts,
+  ) {
     super(changeDetector);
+    this.interventionMap = gtmContexts.interventionMap;
   }
 
   getInitialData$() {

--- a/frontend/src/app/modules/nav/desktop-nav/desktop-nav.component.html
+++ b/frontend/src/app/modules/nav/desktop-nav/desktop-nav.component.html
@@ -1,4 +1,4 @@
-<div class='nav-buttons-container'>
+<div class='nav-buttons-container' [withGtmContext]="gtmContext">
     <ng-container *ngIf="isLoggedIn">
         <button mat-button routerLink='/interwencje'
                 routerLinkActive="active"
@@ -21,7 +21,7 @@
         Zgłoś interwencję
     </button>
 </div>
-<div class='auth-buttons-container'>
+<div class='auth-buttons-container' [withGtmContext]="gtmContext">
     <button *ngIf='!isLoggedIn' class="login" mat-button (click)='logIn.emit()'>
         <mat-icon>account_circle</mat-icon>
         Zaloguj

--- a/frontend/src/app/modules/nav/desktop-nav/desktop-nav.component.ts
+++ b/frontend/src/app/modules/nav/desktop-nav/desktop-nav.component.ts
@@ -8,6 +8,7 @@ import {ChangeDetectionStrategy, Component, EventEmitter, Input, Output} from '@
 })
 export class DesktopNavComponent {
     @Input() isLoggedIn = false;
+    @Input() gtmContext;
     @Output() logIn = new EventEmitter();
     @Output() logOut = new EventEmitter();
 }

--- a/frontend/src/app/modules/nav/mobile-nav/mobile-nav.component.html
+++ b/frontend/src/app/modules/nav/mobile-nav/mobile-nav.component.html
@@ -1,6 +1,6 @@
 <mat-sidenav-container>
     <mat-sidenav #sidenav [autoFocus]="false">
-        <mat-nav-list>
+        <mat-nav-list [withGtmContext]="mobileNavGtmContext">
 
             <ng-container *ngIf="isLoggedIn$ | async">
                 <mat-list-item>Witaj, Inspektorze!</mat-list-item>

--- a/frontend/src/app/modules/nav/mobile-nav/mobile-nav.component.ts
+++ b/frontend/src/app/modules/nav/mobile-nav/mobile-nav.component.ts
@@ -1,9 +1,10 @@
-import {Component, OnInit, ViewChild} from '@angular/core';
+import {Component, Inject, OnInit, ViewChild} from '@angular/core';
 import {MatSidenav} from '@angular/material';
 import {ComponentWithSubscriptions} from '@shared/base';
 
 import {AuthService} from '../../auth/auth.service';
 import {BreakpointService} from '../../../shared/services/breakpoint.service';
+import {GTM_CONTEXTS} from '../../shared/google-tag-manager/gtm-contexts';
 
 interface MenuItem {
   text: string;
@@ -71,11 +72,17 @@ const menuItems = {
 })
 export class MobileNavComponent extends ComponentWithSubscriptions implements OnInit {
   menuItems: MenuItems = menuItems;
+  mobileNavGtmContext: string;
   isLoggedIn$ = this.authService.isLoggedIn$;
   @ViewChild('sidenav', {static: false}) sidenav: MatSidenav;
 
-  constructor(private authService: AuthService, private breakpointService: BreakpointService) {
+  constructor(
+      private authService: AuthService,
+      private breakpointService: BreakpointService,
+      @Inject(GTM_CONTEXTS) gtmContexts,
+  ) {
     super();
+    this.mobileNavGtmContext = gtmContexts.mobileNav;
   }
 
   ngOnInit() {

--- a/frontend/src/app/modules/nav/nav.component.html
+++ b/frontend/src/app/modules/nav/nav.component.html
@@ -4,6 +4,7 @@
         <app-desktop-nav
                 *ngIf="!(isMobileView$ | async)"
                 [isLoggedIn]="isLoggedIn$ | async"
+                [gtmContext]="desktopNavGtmContext"
                 (logIn)="logIn()"
                 (logOut)="logOut()">
         </app-desktop-nav>
@@ -15,6 +16,7 @@
     <button *ngIf="isMobileView$ | async"
             class="hamburger-menu"
             mat-icon-button
+            [withGtmContext]="hamburgerMenuButtonGtmContext"
             (click)='sideNavToggle.emit()'>
         <mat-icon>menu</mat-icon>
     </button>

--- a/frontend/src/app/modules/nav/nav.component.ts
+++ b/frontend/src/app/modules/nav/nav.component.ts
@@ -1,8 +1,9 @@
-import {Component, EventEmitter, OnInit, Output} from '@angular/core';
+import {Component, EventEmitter, Inject, OnInit, Output} from '@angular/core';
 import {Observable} from 'rxjs';
 
 import {AuthService} from '../auth/auth.service';
 import {BreakpointService} from '../../shared/services/breakpoint.service';
+import {GTM_CONTEXTS} from '../shared/google-tag-manager/gtm-contexts';
 
 @Component({
   selector: 'app-nav',
@@ -10,11 +11,22 @@ import {BreakpointService} from '../../shared/services/breakpoint.service';
   styleUrls: ['./nav.component.scss']
 })
 export class NavComponent implements OnInit {
+  desktopNavGtmContext: string;
+  hamburgerMenuButtonGtmContext: string;
+
   isMobileView$: Observable<boolean>;
   isLoggedIn$ = this.authService.isLoggedIn$;
+
   @Output() sideNavToggle = new EventEmitter();
 
-  constructor(private breakpointService: BreakpointService, private authService: AuthService) {}
+  constructor(
+      private breakpointService: BreakpointService,
+      private authService: AuthService,
+      @Inject(GTM_CONTEXTS) gtmContexts,
+  ) {
+    this.desktopNavGtmContext = gtmContexts.desktopNav;
+    this.hamburgerMenuButtonGtmContext = gtmContexts.hamburgerMenuButton;
+  }
 
   ngOnInit(): void {
     this.isMobileView$ = this.breakpointService.isMobileView$;

--- a/frontend/src/app/modules/nav/nav.module.ts
+++ b/frontend/src/app/modules/nav/nav.module.ts
@@ -1,11 +1,12 @@
 import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {MatButtonModule, MatIconModule, MatListModule, MatNavList, MatSidenavModule, MatToolbarModule} from '@angular/material';
+import {MatButtonModule, MatIconModule, MatListModule, MatSidenavModule, MatToolbarModule} from '@angular/material';
 import {RouterModule} from '@angular/router';
+import {SharedModule} from '../shared/shared.module';
 
 import {NavComponent} from './nav.component';
-import { DesktopNavComponent } from './desktop-nav/desktop-nav.component';
-import { MobileNavComponent } from './mobile-nav/mobile-nav.component';
+import {DesktopNavComponent} from './desktop-nav/desktop-nav.component';
+import {MobileNavComponent} from './mobile-nav/mobile-nav.component';
 
 @NgModule({
   declarations: [
@@ -21,6 +22,7 @@ import { MobileNavComponent } from './mobile-nav/mobile-nav.component';
     MatSidenavModule,
     MatToolbarModule,
     RouterModule,
+    SharedModule,
   ],
   exports: [
     NavComponent,

--- a/frontend/src/app/modules/shared/google-tag-manager/gtm-context.directive.spec.data.ts
+++ b/frontend/src/app/modules/shared/google-tag-manager/gtm-context.directive.spec.data.ts
@@ -1,0 +1,36 @@
+import {Component} from '@angular/core';
+
+const initialData = {
+    gtmContext: 'testContext',
+    gtmData: {
+        testData1: 'testGtmData1',
+        testData2: 'testGtmData2',
+    }
+};
+const expectedAttributeKeys = ['data-gtm-context', 'data-gtm-test-data1', 'data-gtm-test-data2'];
+const expectedDatasetKeys = {
+    gtmContext: 'gtmContext',
+    testData1: 'gtmTestData1',
+    testData2: 'gtmTestData2',
+};
+const noGtmContextNoGtmDataSelector =
+    `span:not([${expectedAttributeKeys[0]}]):not([${expectedAttributeKeys[1]}]):not([${expectedAttributeKeys[2]}])`;
+
+@Component({
+    template: `
+        <span [withGtmContext]="gtmContext">Test gtm context</span>
+        <span [withGtmContext]="gtmContext" [gtmData]="gtmData">Test gtm context with gtm data</span>
+        <span withGtmContext [gtmData]="gtmData">Test gtm data - no context</span>
+        <span>No context, no data</span>
+    `,
+})
+export class GtmContextDirectiveTestComponent {
+    gtmContext = initialData.gtmContext;
+    gtmData = initialData.gtmData;
+}
+
+export const gtmContextDirectiveSpecData = {
+    initialData,
+    expectedDatasetKeys,
+    noGtmContextNoGtmDataSelector,
+};

--- a/frontend/src/app/modules/shared/google-tag-manager/gtm-context.directive.spec.ts
+++ b/frontend/src/app/modules/shared/google-tag-manager/gtm-context.directive.spec.ts
@@ -1,0 +1,63 @@
+import { DebugElement} from '@angular/core';
+import {By} from '@angular/platform-browser';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import { GtmContextDirective } from './gtm-context.directive';
+import {gtmContextDirectiveSpecData, GtmContextDirectiveTestComponent} from './gtm-context.directive.spec.data';
+
+describe('GtmContextDirective', () => {
+    const {
+        initialData,
+        expectedDatasetKeys,
+        noGtmContextNoGtmDataSelector,
+    } = gtmContextDirectiveSpecData;
+
+    const getDatasetValueByKey = (element: HTMLElement, datasetKey: string): string => element.dataset[datasetKey];
+
+    const createFixture = () =>
+        TestBed.configureTestingModule({
+            declarations: [GtmContextDirective, GtmContextDirectiveTestComponent]
+        }).createComponent(GtmContextDirectiveTestComponent);
+
+    let elementsWithGtmContext: DebugElement[];
+    let fixture: ComponentFixture<GtmContextDirectiveTestComponent>;
+
+    beforeEach(() => {
+        fixture = createFixture();
+        fixture.detectChanges();
+        elementsWithGtmContext = fixture.debugElement.queryAll(By.directive(GtmContextDirective));
+    });
+
+    it('should have three elements with gtm context', () => {
+        expect(elementsWithGtmContext.length).toEqual(3);
+    });
+
+    it('should have element with no gtm context and no gtm data', () => {
+        const span = fixture.debugElement.query(By.css(noGtmContextNoGtmDataSelector));
+        expect(span).toBeTruthy();
+    });
+
+    it('should have element with gtm context but no gtm data attribute', () => {
+        const testedElement = elementsWithGtmContext[0].nativeElement;
+
+        expect(getDatasetValueByKey(testedElement, expectedDatasetKeys.gtmContext)).toEqual(initialData.gtmContext);
+        expect(getDatasetValueByKey(testedElement, expectedDatasetKeys.testData1)).toBeUndefined();
+        expect(getDatasetValueByKey(testedElement, expectedDatasetKeys.testData2)).toBeUndefined();
+    });
+
+    it('should have element with gtm context and both gtm data attributes', () => {
+        const testedElement = elementsWithGtmContext[1].nativeElement;
+
+        expect(getDatasetValueByKey(testedElement, expectedDatasetKeys.gtmContext)).toEqual(initialData.gtmContext);
+        expect(getDatasetValueByKey(testedElement, expectedDatasetKeys.testData1)).toEqual(initialData.gtmData.testData1);
+        expect(getDatasetValueByKey(testedElement, expectedDatasetKeys.testData2)).toEqual(initialData.gtmData.testData2);
+    });
+
+    it('should have element with no gtm context but both gtm data attributes', () => {
+        const testedElement = elementsWithGtmContext[2].nativeElement;
+
+        expect(getDatasetValueByKey(testedElement, expectedDatasetKeys.gtmContext)).toBeUndefined();
+        expect(getDatasetValueByKey(testedElement, expectedDatasetKeys.testData1)).toEqual(initialData.gtmData.testData1);
+        expect(getDatasetValueByKey(testedElement, expectedDatasetKeys.testData2)).toEqual(initialData.gtmData.testData2);
+    });
+});

--- a/frontend/src/app/modules/shared/google-tag-manager/gtm-context.directive.ts
+++ b/frontend/src/app/modules/shared/google-tag-manager/gtm-context.directive.ts
@@ -1,0 +1,36 @@
+import {Directive, ElementRef, Input, OnInit} from '@angular/core';
+
+interface GtmData {
+  [key: string]: string;
+}
+
+@Directive({
+  selector: '[withGtmContext]'
+})
+export class GtmContextDirective implements OnInit {
+  @Input('withGtmContext') context: string;
+  @Input() gtmData: GtmData;
+
+  constructor(private el: ElementRef) {}
+
+  ngOnInit() {
+    const element = this.el.nativeElement;
+    addGtmContextToDataset(this.context, element);
+    addGtmDataToDataset(this.gtmData, element);
+  }
+}
+
+const addGtmContextToDataset = (context: string, element: HTMLElement) => {
+  if (!context) return;
+  element.dataset.gtmContext = context;
+};
+
+const addGtmDataToDataset = (gtmData: GtmData, element: HTMLElement) => {
+  if (!gtmData) return;
+  for (const [attributeName, attributeValue] of Object.entries(gtmData)) {
+    element.dataset[addGtmPrefix(attributeName)] = attributeValue;
+  }
+};
+
+const addGtmPrefix = (unprefixedName: string): string =>
+    'gtm' + unprefixedName[0].toUpperCase() + unprefixedName.slice(1);

--- a/frontend/src/app/modules/shared/google-tag-manager/gtm-contexts.ts
+++ b/frontend/src/app/modules/shared/google-tag-manager/gtm-contexts.ts
@@ -1,0 +1,7 @@
+import {InjectionToken} from '@angular/core';
+
+interface GtmContexts {
+    [key: string]: string;
+}
+
+export const GTM_CONTEXTS = new InjectionToken<GtmContexts>('google-tag-manager-contexts');

--- a/frontend/src/app/modules/shared/google-tag-manager/gtm-script.ts
+++ b/frontend/src/app/modules/shared/google-tag-manager/gtm-script.ts
@@ -1,0 +1,17 @@
+import {Renderer2} from '@angular/core';
+import {environment} from '@environment';
+
+const GTM_INIT_SCRIPT =
+    `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer', '${environment.tagManagerId}');`;
+
+export function renderGTMInitScript(renderer: Renderer2, DOMElement: Element) {
+    const script = renderer.createElement('script');
+    script.type = `text/javascript`;
+    script.text = GTM_INIT_SCRIPT;
+
+    renderer.appendChild(DOMElement, script);
+}

--- a/frontend/src/app/modules/shared/shared.module.ts
+++ b/frontend/src/app/modules/shared/shared.module.ts
@@ -3,13 +3,14 @@ import { CommonModule } from '@angular/common';
 import { MatProgressSpinnerModule } from '@angular/material';
 
 import { LoaderComponent } from './loader/loader.component';
+import { GtmContextDirective } from './google-tag-manager/gtm-context.directive';
 
 @NgModule({
-  declarations: [LoaderComponent],
+  declarations: [LoaderComponent, GtmContextDirective],
   imports: [
       MatProgressSpinnerModule,
       CommonModule
   ],
-  exports: [LoaderComponent]
+  exports: [LoaderComponent, GtmContextDirective]
 })
 export class SharedModule { }

--- a/frontend/src/environments/environment.common.ts
+++ b/frontend/src/environments/environment.common.ts
@@ -1,0 +1,12 @@
+export interface Environment {
+    production: boolean;
+    useSentry: boolean;
+    sentryDSN: string;
+    useGoogleTagManager: boolean;
+    tagManagerId: string;
+}
+
+export const commonEnvironment: Pick<Environment, 'sentryDSN' | 'tagManagerId'> = {
+    sentryDSN: 'https://bc6889e92f5d4c9d941ed23760f38d37@sentry.io/1548140',
+    tagManagerId: 'GTM-PH9WQ8J',
+};

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,5 +1,8 @@
-export const environment = {
+import {commonEnvironment, Environment} from './environment.common';
+
+export const environment: Environment = {
   production: true,
   useSentry: true,
-  sentryDSN: 'https://bc6889e92f5d4c9d941ed23760f38d37@sentry.io/1548140',
+  useGoogleTagManager: true,
+  ...commonEnvironment,
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -2,10 +2,13 @@
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
-export const environment = {
+import {commonEnvironment, Environment} from './environment.common';
+
+export const environment: Environment = {
   production: false,
-  useSentry: false, // switch on this flag to test Sentry locally
-  sentryDSN: 'https://bc6889e92f5d4c9d941ed23760f38d37@sentry.io/1548140',
+  useSentry: false,
+  useGoogleTagManager: false,
+  ...commonEnvironment,
 };
 
 /*

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,7 +2,7 @@ import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 import { AppModule } from './app/app.module';
-import { environment } from './environments/environment';
+import { environment } from '@environment';
 
 if (environment.production) {
   enableProdMode();

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -9,6 +9,7 @@
   ],
   "exclude": [
     "src/test.ts",
-    "src/**/*.spec.ts"
+    "src/**/*.spec.ts",
+    "src/**/*.spec.data.ts"
   ]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -13,7 +13,8 @@
     "paths": {
       "@shared/base": ["./src/app/shared/base/index.ts"],
       "@shared/*": ["./src/app/shared/*"],
-      "@interventionForm/*": ["./src/app/modules/intervention-form/*"]
+      "@interventionForm/*": ["./src/app/modules/intervention-form/*"],
+      "@environment": ["./src/environments/environment.ts"]
     },
     "target": "es2015",
     "typeRoots": [

--- a/frontend/tslint.json
+++ b/frontend/tslint.json
@@ -14,6 +14,7 @@
       true,
       "attribute",
       "app",
+      "with",
       "camelCase"
     ],
     "component-selector": [


### PR DESCRIPTION
This PR adds GoogleTagManager initial script and contexts used as a data helper for GoogleTagManager tags. 

Aside from the code in this PR, I have also set up numerous tags in Google's Tag Manager Ekostraz workspace for Google Analytics tracking purposes. 
Please let me know if you'd like to be added to the aforementioned workspace.

Closes #26 