### PR TITLE
fix(locale): Provide locale data before app bootstrap

### DIFF
--- a/frontend/src/app/providerFactories.ts
+++ b/frontend/src/app/providerFactories.ts
@@ -1,10 +1,7 @@
 import { ErrorHandler } from '@angular/core';
-import { registerLocaleData } from '@angular/common';
-import { default as localePl } from '@angular/common/locales/pl';
 import { SentryErrorHandler } from './SentryErrorHandler';
 
 export function localeProviderFactory(): string {
-  registerLocaleData(localePl);
   return 'pl';
 }
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,4 +1,6 @@
 import { enableProdMode } from '@angular/core';
+import { registerLocaleData } from '@angular/common';
+import { default as localePl } from '@angular/common/locales/pl';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 import { AppModule } from './app/app.module';
@@ -7,6 +9,8 @@ import { environment } from '@environment';
 if (environment.production) {
   enableProdMode();
 }
+
+registerLocaleData(localePl);
 
 platformBrowserDynamic()
   .bootstrapModule(AppModule)


### PR DESCRIPTION
Fixes a bug where locale data is needed on first view render, but still not available due to provider registring it later.