### PR TITLE
chore(frontend/package.json): Add "npm run start:host" script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --aot",
+    "start:host": "ng serve --aot --host",
     "build": "ng build --aot",
     "test": "ng test --browsers=ChromeHeadlessCustom",
     "test:ci": "ng test --watch=false --browsers=ChromeHeadlessCustom",


### PR DESCRIPTION
Adds "npm run start:host" script for running frontend.

It allows for serving frontend through a local network.
It might be useful for testing the app on other devices - e.g. mobile phone, tablets.

When the app is successfuly built and served, just enter your local ip address and serving port to access the app on other devices.