### PR TITLE
fix(frontend/comments): Change "Add comment" displayed string to "Do…

### DIFF
--- a/frontend/src/app/modules/interventions/details/comments/comments.component.html
+++ b/frontend/src/app/modules/interventions/details/comments/comments.component.html
@@ -10,9 +10,9 @@
 
 <form [formGroup]="form" (ngSubmit)="addComment()" class="form" novalidate>
   <div class="form-row">
-    <textarea class="input" formControlName="comment" placeholder="Add comment..." required></textarea>
+    <textarea class="input" formControlName="comment" placeholder="Dodaj komentarz..." required></textarea>
   </div>
   <div class="form-row">
-    <input type="submit" value="Add Comment" [disabled]="!form.valid" />
+    <input type="submit" value="Dodaj komentarz" [disabled]="!form.valid" />
   </div>
 </form>


### PR DESCRIPTION
…daj komentarz"

Missed that during review when we were adding the feature. The app will be used mainly in Poland so until we support multilang, there's no need for english caption IMO.