### PR TITLE
refactor(frontend/intervention-form): Embed FileUploader inside the form

### DIFF
--- a/frontend/src/app/modules/intervention-form/file-uploader/file-uploader.component.html
+++ b/frontend/src/app/modules/intervention-form/file-uploader/file-uploader.component.html
@@ -1,27 +1,24 @@
-<section class="attachments">
-  <h2 class="mat-h2">Załączniki</h2>
-  <span *ngIf="files.length" class="file-counter">Wybrano {{ files.length }}</span>
+<span *ngIf="files.length" class="file-counter">Wybrano {{ files.length }}</span>
 
-  <div class="uploader-container">
-    <p *ngIf="!files.length && !editTemporaryDisabled" class="add-files-text">{{ addFilesMessage }}</p>
-    <p *ngIf="editTemporaryDisabled" class="add-files-text">Edytowanie załączników chwilowo niedostępne</p>
-    <div class="thumbs-container" *ngIf="!editTemporaryDisabled">
-      <eko-file-thumb *ngFor="let file of files" [file]="file" (fileRemove)="onFileRemove($event)"> </eko-file-thumb>
+<div class="uploader-container">
+  <p *ngIf="!files.length" class="add-files-text">{{ addFilesMessage }}</p>
+  <div class="thumbs-container">
+    <eko-file-thumb *ngFor="let file of files" [file]="file" (fileRemove)="onFileRemove($event, fileInput)">
+    </eko-file-thumb>
 
-      <div class="fab-container">
-        <button type="button" color="primary" mat-mini-fab (click)="openFileBrowser(fileInput)">
-          <mat-icon>add</mat-icon>
-        </button>
-      </div>
+    <div class="fab-container">
+      <button type="button" color="primary" mat-mini-fab (click)="openFileBrowser(fileInput)">
+        <mat-icon>add</mat-icon>
+      </button>
     </div>
-
-    <input
-      #fileInput
-      multiple
-      type="file"
-      hidden
-      accept="{{ acceptedFileTypes }}"
-      (change)="onFilesSelected(fileInput)"
-    />
   </div>
-</section>
+
+  <input
+    #fileInput
+    multiple
+    type="file"
+    hidden
+    accept="{{ acceptedFileTypes }}"
+    (change)="onFilesSelected(fileInput)"
+  />
+</div>

--- a/frontend/src/app/modules/intervention-form/file-uploader/file-uploader.component.scss
+++ b/frontend/src/app/modules/intervention-form/file-uploader/file-uploader.component.scss
@@ -1,12 +1,10 @@
 @import 'breakpoints';
 $font-color: rgba(200, 200, 200, 0.8);
 
-.attachments {
+:host {
   position: relative;
-
-  & > h2 {
-    margin-bottom: 1em;
-  }
+  display: block;
+  padding-top: 10px;
 }
 
 .add-files-text {
@@ -37,7 +35,7 @@ $font-color: rgba(200, 200, 200, 0.8);
 
 .file-counter {
   position: absolute;
-  top: 2em;
+  top: -0.8em;
   right: 0;
   font-style: oblique;
 }

--- a/frontend/src/app/modules/intervention-form/file-uploader/file-uploader.component.ts
+++ b/frontend/src/app/modules/intervention-form/file-uploader/file-uploader.component.ts
@@ -16,7 +16,6 @@ export enum SupportedFileTypes {
 })
 export class FileUploaderComponent implements OnInit {
   @Input() imagesOnly = false;
-  @Input() editTemporaryDisabled = false;
 
   files: Array<File> = [];
   addFilesMessage: string;
@@ -48,8 +47,9 @@ export class FileUploaderComponent implements OnInit {
     );
   }
 
-  onFileRemove(removedFile: File) {
+  onFileRemove(removedFile: File, input: HTMLInputElement) {
     this.files = this.files.filter(file => file !== removedFile);
+    input.value = '';
   }
 
   private getAllSupportedTypes(): string {

--- a/frontend/src/app/modules/intervention-form/form/form.component.html
+++ b/frontend/src/app/modules/intervention-form/form/form.component.html
@@ -76,7 +76,10 @@
         </mat-form-field>
       </section>
 
-      <ng-content></ng-content>
+      <section class="attachments">
+        <h2 class="mat-h2">Załączniki</h2>
+        <eko-file-uploader [imagesOnly]="!this.inPrivateMode"></eko-file-uploader>
+      </section>
 
       <button type="submit" color="primary" mat-raised-button [disabled]="!form.valid || submitInProgress">
         <mat-spinner *ngIf="submitInProgress" [diameter]="25"></mat-spinner>

--- a/frontend/src/app/modules/interventions/edit-form/edit-form.component.html
+++ b/frontend/src/app/modules/interventions/edit-form/edit-form.component.html
@@ -8,7 +8,6 @@
     [submitInProgress]="submitInProgress"
     (formSubmit)="onSubmit($event)"
   >
-    <eko-file-uploader [editTemporaryDisabled]="true"></eko-file-uploader>
   </app-intervention-form>
   <h3 *ngIf="!intervention">Nie udało się pobrać danych z serwera!</h3>
 </app-loader>

--- a/frontend/src/app/modules/interventions/new-form/new-form.component.html
+++ b/frontend/src/app/modules/interventions/new-form/new-form.component.html
@@ -1,3 +1,2 @@
 <app-intervention-form [inPrivateMode]="true" [submitInProgress]="submitInProgress" (formSubmit)="onSubmit($event)">
-  <eko-file-uploader></eko-file-uploader>
 </app-intervention-form>

--- a/frontend/src/app/modules/public-form/public-form/public-form.component.html
+++ b/frontend/src/app/modules/public-form/public-form/public-form.component.html
@@ -1,3 +1,2 @@
 <app-intervention-form [inPrivateMode]="false" [submitInProgress]="submitInProgress" (formSubmit)="onSubmit($event)">
-  <eko-file-uploader [imagesOnly]="true"></eko-file-uploader>
 </app-intervention-form>


### PR DESCRIPTION
Changing the previous concept.

It will actually make it easier to call the API if we embed the file uploader in the form and return the files onSubmit event (will be added in next PR)