### PR TITLE
add sorting and paging to interventions table

### DIFF
--- a/frontend/src/app/modules/interventions/interventions.module.ts
+++ b/frontend/src/app/modules/interventions/interventions.module.ts
@@ -9,6 +9,7 @@ import {
   MatPaginatorModule,
   MatRadioModule,
   MatTableModule,
+  MatSortModule,
 } from '@angular/material';
 
 import { AgmCoreModule, LAZY_MAPS_API_CONFIG } from '@agm/core';
@@ -41,6 +42,7 @@ const MaterialImports = [
   MatPaginatorModule,
   MatRadioModule,
   MatTableModule,
+  MatSortModule,
 ];
 
 @NgModule({

--- a/frontend/src/app/modules/interventions/list/list.component.html
+++ b/frontend/src/app/modules/interventions/list/list.component.html
@@ -4,7 +4,5 @@
     Sprawdź na mapie!
     <mat-icon>map</mat-icon>
   </button>
-  <eko-loader [loading$]="loading$">
   <app-interventions-table></app-interventions-table>
-  </eko-loader>
 </section>

--- a/frontend/src/app/modules/interventions/list/list.component.html
+++ b/frontend/src/app/modules/interventions/list/list.component.html
@@ -4,5 +4,5 @@
     Sprawdź na mapie!
     <mat-icon>map</mat-icon>
   </button>
-  <app-interventions-table></app-interventions-table>
+  <eko-interventions-table></eko-interventions-table>
 </section>

--- a/frontend/src/app/modules/interventions/list/list.component.html
+++ b/frontend/src/app/modules/interventions/list/list.component.html
@@ -1,10 +1,10 @@
 <section class="InterventionsList" [withGtmContext]="interventionsListGtmContext">
   <h1 class="mat-h1">Lista interwencji</h1>
-  <button (click)="showMap()" color="primary" mat-raised-button [disabled]="!interventions">
+  <button (click)="showMap()" color="primary" mat-raised-button>
     Sprawdź na mapie!
     <mat-icon>map</mat-icon>
   </button>
   <eko-loader [loading$]="loading$">
-    <app-interventions-table [interventions]="interventions"></app-interventions-table>
+  <app-interventions-table></app-interventions-table>
   </eko-loader>
 </section>

--- a/frontend/src/app/modules/interventions/list/list.component.ts
+++ b/frontend/src/app/modules/interventions/list/list.component.ts
@@ -1,11 +1,5 @@
 import { Component, Inject } from '@angular/core';
 import { Router } from '@angular/router';
-
-import { Observable } from 'rxjs';
-import { map, tap } from 'rxjs/operators';
-
-import { Intervention, ListIntervention } from '@shared/domain/intervention.model';
-import { InterventionsService } from '../interventions.service';
 import { GTM_CONTEXTS } from '@shared/google-tag-manager/gtm-contexts';
 
 @Component({
@@ -15,30 +9,12 @@ import { GTM_CONTEXTS } from '@shared/google-tag-manager/gtm-contexts';
 })
 export class ListComponent {
   interventionsListGtmContext: string;
-  interventions: ListIntervention[];
-  loading$: Observable<ListIntervention[]> = this.interventionsService.getInterventions().pipe(
-    map(toTableData),
-    tap(data => {
-      this.interventions = data;
-    }),
-  );
 
-  constructor(
-    private router: Router,
-    private interventionsService: InterventionsService,
-    @Inject(GTM_CONTEXTS) gtmContexts,
-  ) {
+  constructor(private router: Router, @Inject(GTM_CONTEXTS) gtmContexts) {
     this.interventionsListGtmContext = gtmContexts.interventionList;
   }
 
   showMap() {
     this.router.navigate(['interwencje', 'mapa']);
   }
-}
-
-function toTableData(interventions: Intervention[]): ListIntervention[] {
-  return interventions.map((intervention, index) => ({
-    ...intervention,
-    position: index + 1,
-  }));
 }

--- a/frontend/src/app/modules/interventions/list/table/interventions.datasource.ts
+++ b/frontend/src/app/modules/interventions/list/table/interventions.datasource.ts
@@ -1,0 +1,36 @@
+import { CollectionViewer, DataSource } from '@angular/cdk/collections';
+import { Observable, BehaviorSubject, of } from 'rxjs';
+
+import { InterventionsService } from '../../interventions.service';
+import { catchError, finalize } from 'rxjs/operators';
+
+import { Intervention, InterventionsFilter } from '@shared/domain/intervention.model';
+
+export class InterventionsDatasource implements DataSource<Intervention> {
+  private interventionSubject = new BehaviorSubject<Intervention[]>([]);
+  private loadingSubject = new BehaviorSubject<boolean>(false);
+
+  public loading$ = this.loadingSubject.asObservable();
+
+  constructor(private interventionsService: InterventionsService) {}
+
+  connect(collectionViewer: CollectionViewer): Observable<Intervention[]> {
+    return this.interventionSubject.asObservable();
+  }
+
+  disconnect(collectionViewer: CollectionViewer): void {
+    this.interventionSubject.complete();
+    this.loadingSubject.complete();
+  }
+
+  loadInterventions(params: InterventionsFilter) {
+    this.loadingSubject.next(true);
+    this.interventionsService
+      .getInterventions(params)
+      .pipe(
+        catchError(() => of([])),
+        finalize(() => this.loadingSubject.next(false)),
+      )
+      .subscribe(interventions => this.interventionSubject.next(interventions));
+  }
+}

--- a/frontend/src/app/modules/interventions/list/table/table.component.html
+++ b/frontend/src/app/modules/interventions/list/table/table.component.html
@@ -4,7 +4,9 @@
       <!-- Position Column -->
       <ng-container matColumnDef="position">
         <mat-header-cell *matHeaderCellDef>L.p.</mat-header-cell>
-        <mat-cell *matCellDef="let element" data-label="Numer">{{ element.position }}</mat-cell>
+        <mat-cell *matCellDef="let index = index" data-label="Numer">{{
+          index + this.paginator.pageIndex * this.paginator.pageSize + 1
+        }}</mat-cell>
       </ng-container>
 
       <!-- Name Column -->

--- a/frontend/src/app/modules/interventions/list/table/table.component.html
+++ b/frontend/src/app/modules/interventions/list/table/table.component.html
@@ -1,5 +1,8 @@
+<div class="spinner-container" *ngIf="dataSource.loading$ | async">
+  <mat-spinner></mat-spinner>
+</div>
 <div class="mat-elevation-z8">
-  <mat-table [dataSource]="dataSource">
+  <mat-table [dataSource]="dataSource" matSort matSortDisableClear matSortActive="date" matSortDirection="desc">
     <!-- Position Column -->
     <ng-container matColumnDef="position">
       <mat-header-cell *matHeaderCellDef>L.p.</mat-header-cell>
@@ -26,7 +29,7 @@
 
     <!-- Date Column -->
     <ng-container matColumnDef="date">
-      <mat-header-cell *matHeaderCellDef>Data dodania</mat-header-cell>
+      <mat-header-cell *matHeaderCellDef mat-sort-header>Data dodania</mat-header-cell>
       <mat-cell *matCellDef="let element" data-label="Data dodania">{{
         element.creationDate | date: 'medium'
       }}</mat-cell>
@@ -44,5 +47,5 @@
     <mat-row *matRowDef="let element; columns: displayedColumns" (click)="showDetails(element)"></mat-row>
   </mat-table>
 
-  <mat-paginator [pageSize]="10" [pageSizeOptions]="[10, 25, 50, 100]"> </mat-paginator>
+  <mat-paginator [pageSize]="10" [pageSizeOptions]="[10, 25, 50, 100]" [length]="100"></mat-paginator>
 </div>

--- a/frontend/src/app/modules/interventions/list/table/table.component.html
+++ b/frontend/src/app/modules/interventions/list/table/table.component.html
@@ -1,51 +1,50 @@
-<div class="spinner-container" *ngIf="dataSource.loading$ | async">
-  <mat-spinner></mat-spinner>
-</div>
-<div class="mat-elevation-z8">
-  <mat-table [dataSource]="dataSource" matSort matSortDisableClear matSortActive="date" matSortDirection="desc">
-    <!-- Position Column -->
-    <ng-container matColumnDef="position">
-      <mat-header-cell *matHeaderCellDef>L.p.</mat-header-cell>
-      <mat-cell *matCellDef="let element" data-label="Numer">{{ element.position }}</mat-cell>
-    </ng-container>
+<eko-loader [loading$]="dataSource.loading$" [cover]="true">
+  <div class="mat-elevation-z8">
+    <mat-table [dataSource]="dataSource" matSort matSortDisableClear matSortActive="date" matSortDirection="desc">
+      <!-- Position Column -->
+      <ng-container matColumnDef="position">
+        <mat-header-cell *matHeaderCellDef>L.p.</mat-header-cell>
+        <mat-cell *matCellDef="let element" data-label="Numer">{{ element.position }}</mat-cell>
+      </ng-container>
 
-    <!-- Name Column -->
-    <ng-container matColumnDef="name">
-      <mat-header-cell *matHeaderCellDef>Imię i nazwisko</mat-header-cell>
-      <mat-cell *matCellDef="let element" data-label="Imię i nazwisko">{{ element.fullName || 'Brak' }}</mat-cell>
-    </ng-container>
+      <!-- Name Column -->
+      <ng-container matColumnDef="name">
+        <mat-header-cell *matHeaderCellDef>Imię i nazwisko</mat-header-cell>
+        <mat-cell *matCellDef="let element" data-label="Imię i nazwisko">{{ element.fullName || 'Brak' }}</mat-cell>
+      </ng-container>
 
-    <!-- Status Column -->
-    <ng-container matColumnDef="status">
-      <mat-header-cell *matHeaderCellDef>Status</mat-header-cell>
-      <mat-cell *matCellDef="let element" data-label="Status">{{ element.status | ekoInterventionStatus }}</mat-cell>
-    </ng-container>
+      <!-- Status Column -->
+      <ng-container matColumnDef="status">
+        <mat-header-cell *matHeaderCellDef>Status</mat-header-cell>
+        <mat-cell *matCellDef="let element" data-label="Status">{{ element.status | ekoInterventionStatus }}</mat-cell>
+      </ng-container>
 
-    <!-- Phone Column -->
-    <ng-container matColumnDef="phone">
-      <mat-header-cell *matHeaderCellDef>Telefon</mat-header-cell>
-      <mat-cell *matCellDef="let element" data-label="Telefon">{{ element.phoneNumber }}</mat-cell>
-    </ng-container>
+      <!-- Phone Column -->
+      <ng-container matColumnDef="phone">
+        <mat-header-cell *matHeaderCellDef>Telefon</mat-header-cell>
+        <mat-cell *matCellDef="let element" data-label="Telefon">{{ element.phoneNumber }}</mat-cell>
+      </ng-container>
 
-    <!-- Date Column -->
-    <ng-container matColumnDef="date">
-      <mat-header-cell *matHeaderCellDef mat-sort-header>Data dodania</mat-header-cell>
-      <mat-cell *matCellDef="let element" data-label="Data dodania">{{
-        element.creationDate | date: 'medium'
-      }}</mat-cell>
-    </ng-container>
+      <!-- Date Column -->
+      <ng-container matColumnDef="date">
+        <mat-header-cell *matHeaderCellDef mat-sort-header>Data dodania</mat-header-cell>
+        <mat-cell *matCellDef="let element" data-label="Data dodania">{{
+          element.creationDate | date: 'medium'
+        }}</mat-cell>
+      </ng-container>
 
-    <!-- Description Column -->
-    <ng-container matColumnDef="description">
-      <mat-header-cell *matHeaderCellDef>Opis</mat-header-cell>
-      <mat-cell *matCellDef="let element" title="{{ element.description }}" data-label="Opis">
-        <span>{{ element.description }}</span>
-      </mat-cell>
-    </ng-container>
+      <!-- Description Column -->
+      <ng-container matColumnDef="description">
+        <mat-header-cell *matHeaderCellDef>Opis</mat-header-cell>
+        <mat-cell *matCellDef="let element" title="{{ element.description }}" data-label="Opis">
+          <span>{{ element.description }}</span>
+        </mat-cell>
+      </ng-container>
 
-    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-    <mat-row *matRowDef="let element; columns: displayedColumns" (click)="showDetails(element)"></mat-row>
-  </mat-table>
+      <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+      <mat-row *matRowDef="let element; columns: displayedColumns" (click)="showDetails(element)"></mat-row>
+    </mat-table>
 
-  <mat-paginator [pageSize]="10" [pageSizeOptions]="[10, 25, 50, 100]" [length]="100"></mat-paginator>
-</div>
+    <mat-paginator [pageSize]="10" [pageSizeOptions]="[10, 25, 50, 100]" [length]="100"></mat-paginator>
+  </div>
+</eko-loader>

--- a/frontend/src/app/modules/interventions/list/table/table.component.html
+++ b/frontend/src/app/modules/interventions/list/table/table.component.html
@@ -5,7 +5,7 @@
       <ng-container matColumnDef="position">
         <mat-header-cell *matHeaderCellDef>L.p.</mat-header-cell>
         <mat-cell *matCellDef="let index = index" data-label="Numer">{{
-          index + this.paginator.pageIndex * this.paginator.pageSize + 1
+          index + paginator.pageIndex * paginator.pageSize + 1
         }}</mat-cell>
       </ng-container>
 

--- a/frontend/src/app/modules/interventions/list/table/table.component.scss
+++ b/frontend/src/app/modules/interventions/list/table/table.component.scss
@@ -38,18 +38,27 @@
   }
 
   .mat-table .mat-header-cell {
-    border: 10px solid;
-    clip: rect(0 0 0 0);
-    height: 1px;
-    margin: -1px;
-    padding: 0;
-    position: absolute;
-    width: 1px;
+    padding-left: 10px;
+    &:nth-child(1),
+    &:nth-child(2),
+    &:nth-child(3),
+    &:nth-child(4),
+    &:nth-child(6) {
+      clip: rect(0 0 0 0);
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      position: absolute;
+      width: 1px;
+    }
   }
-  .mat-header-row {
-    height: 0;
-    min-height: 0;
+
+  .mat-table:before {
+    display: block;
+    content: 'Sortowanie';
+    padding: 10px;
   }
+
   .mat-table .mat-row {
     border-bottom: 5px solid #ddd;
     display: block;

--- a/frontend/src/app/modules/interventions/list/table/table.component.scss
+++ b/frontend/src/app/modules/interventions/list/table/table.component.scss
@@ -38,12 +38,7 @@
   }
 
   .mat-table .mat-header-cell {
-    padding-left: 10px;
-    &:nth-child(1),
-    &:nth-child(2),
-    &:nth-child(3),
-    &:nth-child(4),
-    &:nth-child(6) {
+    &:not([mat-sort-header]) {
       clip: rect(0 0 0 0);
       height: 1px;
       margin: -1px;
@@ -59,12 +54,15 @@
     padding: 10px;
   }
 
-  .mat-table .mat-row {
-    border-bottom: 5px solid #ddd;
-    display: block;
-    padding: 0 12px;
-    &:after {
-      content: unset;
+  .mat-table {
+    .mat-row,
+    .mat-header-row {
+      border-bottom: 5px solid #ddd;
+      display: block;
+      padding: 0 12px;
+      &:after {
+        content: unset;
+      }
     }
   }
 

--- a/frontend/src/app/modules/interventions/list/table/table.component.ts
+++ b/frontend/src/app/modules/interventions/list/table/table.component.ts
@@ -1,38 +1,42 @@
-import { Component, Input, ViewChild, OnChanges, AfterViewInit } from '@angular/core';
+import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
-import { MatTable, MatTableDataSource, MatPaginator } from '@angular/material';
+import { MatPaginator, MatSort, MatTable } from '@angular/material';
 
-import { Intervention } from '@shared/domain/intervention.model';
+import { Intervention, SortDirection, InterventionsFilter } from '@shared/domain/intervention.model';
+import { InterventionsDatasource } from './interventions.datasource';
+import { InterventionsService } from '../../interventions.service';
+import { tap } from 'rxjs/operators';
+import { merge } from 'rxjs';
+
+const defaultSearchParams: InterventionsFilter = {
+  pageSize: 10,
+  page: 1,
+  sortBy: 'creationDate',
+  sortDirection: SortDirection.Descending,
+};
 
 @Component({
   selector: 'app-interventions-table',
   templateUrl: './table.component.html',
   styleUrls: ['./table.component.scss'],
 })
-export class TableComponent implements OnChanges, AfterViewInit {
+export class TableComponent implements AfterViewInit, OnInit {
   displayedColumns = ['position', 'name', 'status', 'phone', 'date', 'description'];
-  dataSource: MatTableDataSource<Intervention>;
-
-  @Input() interventions: Intervention[] = [];
+  dataSource: InterventionsDatasource;
 
   @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
   @ViewChild(MatTable, { static: true }) table: MatTable<any>;
+  @ViewChild(MatSort, { static: true }) sort: MatSort;
 
-  constructor(private router: Router) {}
-
-  ngOnChanges(changes: any) {
-    this.checkInterventions(changes.interventions.currentValue, changes.interventions.previousValue);
-  }
-
-  private checkInterventions(currentInterventions?: Intervention[], previousInterventions?: Intervention[]) {
-    if (currentInterventions !== previousInterventions) {
-      this.dataSource = new MatTableDataSource<Intervention>(currentInterventions);
-      this.dataSource.paginator = this.paginator;
-    }
-  }
+  constructor(private router: Router, private interventionsService: InterventionsService) {}
 
   showDetails(intervention: Intervention) {
     this.router.navigate(['interwencje', intervention.id]);
+  }
+
+  ngOnInit() {
+    this.dataSource = new InterventionsDatasource(this.interventionsService);
+    this.dataSource.loadInterventions(defaultSearchParams);
   }
 
   ngAfterViewInit() {
@@ -40,5 +44,20 @@ export class TableComponent implements OnChanges, AfterViewInit {
     // Remove when fixed. Debounces original ngOnDestroy way after route animation finishes.
     const tableOnDestroy = this.table.ngOnDestroy.bind(this.table);
     this.table.ngOnDestroy = () => setTimeout(tableOnDestroy, 1000);
+    this.sort.sortChange.subscribe(() => (this.paginator.pageIndex = 0));
+    // this.paginator.page.pipe(tap(() => this.loadInterventionsPage())).subscribe();
+    merge(this.sort.sortChange, this.paginator.page)
+      .pipe(tap(() => this.loadInterventionsPage()))
+      .subscribe();
+  }
+
+  loadInterventionsPage() {
+    // API first page is 1, paginator 0
+    const page = this.paginator.pageIndex + 1;
+    this.dataSource.loadInterventions({
+      page,
+      pageSize: this.paginator.pageSize,
+      sortDirection: this.sort.direction === 'asc' ? SortDirection.Ascending : SortDirection.Descending,
+    });
   }
 }

--- a/frontend/src/app/modules/interventions/list/table/table.component.ts
+++ b/frontend/src/app/modules/interventions/list/table/table.component.ts
@@ -5,22 +5,17 @@ import { MatPaginator, MatSort, MatTable } from '@angular/material';
 import { Intervention, SortDirection, InterventionsFilter } from '@shared/domain/intervention.model';
 import { InterventionsDatasource } from './interventions.datasource';
 import { InterventionsService } from '../../interventions.service';
-import { tap } from 'rxjs/operators';
-import { merge } from 'rxjs';
-
-const defaultSearchParams: InterventionsFilter = {
-  pageSize: 10,
-  page: 1,
-  sortBy: 'creationDate',
-  sortDirection: SortDirection.Descending,
-};
+import { tap, startWith, switchMap, map } from 'rxjs/operators';
+import { combineLatest } from 'rxjs';
+import { ComponentWithSubscriptions } from '@shared/components/base';
+import { EkoRoutePaths } from '../../../../eko-route-paths';
 
 @Component({
   selector: 'eko-interventions-table',
   templateUrl: './table.component.html',
   styleUrls: ['./table.component.scss'],
 })
-export class TableComponent implements AfterViewInit, OnInit {
+export class TableComponent extends ComponentWithSubscriptions implements AfterViewInit, OnInit {
   displayedColumns = ['position', 'name', 'status', 'phone', 'date', 'description'];
   dataSource: InterventionsDatasource;
 
@@ -28,15 +23,16 @@ export class TableComponent implements AfterViewInit, OnInit {
   @ViewChild(MatTable, { static: true }) table: MatTable<any>;
   @ViewChild(MatSort, { static: true }) sort: MatSort;
 
-  constructor(private router: Router, private interventionsService: InterventionsService) {}
+  constructor(private router: Router, private interventionsService: InterventionsService) {
+    super();
+  }
 
   showDetails(intervention: Intervention) {
-    this.router.navigate(['interwencje', intervention.id]);
+    this.router.navigate([EkoRoutePaths.Interventions, intervention.id]);
   }
 
   ngOnInit() {
     this.dataSource = new InterventionsDatasource(this.interventionsService);
-    this.dataSource.loadInterventions(defaultSearchParams);
   }
 
   ngAfterViewInit() {
@@ -44,20 +40,32 @@ export class TableComponent implements AfterViewInit, OnInit {
     // Remove when fixed. Debounces original ngOnDestroy way after route animation finishes.
     const tableOnDestroy = this.table.ngOnDestroy.bind(this.table);
     this.table.ngOnDestroy = () => setTimeout(tableOnDestroy, 1000);
-    this.sort.sortChange.subscribe(() => (this.paginator.pageIndex = 0));
-    // this.paginator.page.pipe(tap(() => this.loadInterventionsPage())).subscribe();
-    merge(this.sort.sortChange, this.paginator.page)
-      .pipe(tap(() => this.loadInterventionsPage()))
-      .subscribe();
+    this.subscriptions.add(this.subscribeToSortAndPageChanges());
   }
 
-  loadInterventionsPage() {
-    // API first page is 1, paginator 0
-    const page = this.paginator.pageIndex + 1;
-    this.dataSource.loadInterventions({
-      page,
-      pageSize: this.paginator.pageSize,
-      sortDirection: this.sort.direction === 'asc' ? SortDirection.Ascending : SortDirection.Descending,
+  private subscribeToSortAndPageChanges() {
+    const sort$ = this.sort.sortChange.pipe(
+      tap(() => (this.paginator.pageIndex = 0)),
+      startWith({ active: 'date', direction: 'desc' }),
+    );
+    const page$ = this.paginator.page.pipe(
+      startWith({
+        length: 100,
+        pageIndex: 1,
+        pageSize: 10,
+      }),
+    );
+    const toFilters = ([sort, pageEvent]): InterventionsFilter => ({
+      page: pageEvent.pageIndex + 1, // API first page is 1, paginator 0
+      pageSize: pageEvent.pageSize,
+      sortDirection: sort.direction === 'asc' ? SortDirection.Ascending : SortDirection.Descending,
     });
+
+    combineLatest([sort$, page$])
+      .pipe(
+        map(toFilters),
+        switchMap(filters => this.dataSource.loadInterventions$(filters)),
+      )
+      .subscribe();
   }
 }

--- a/frontend/src/app/modules/interventions/list/table/table.component.ts
+++ b/frontend/src/app/modules/interventions/list/table/table.component.ts
@@ -16,7 +16,7 @@ const defaultSearchParams: InterventionsFilter = {
 };
 
 @Component({
-  selector: 'app-interventions-table',
+  selector: 'eko-interventions-table',
   templateUrl: './table.component.html',
   styleUrls: ['./table.component.scss'],
 })

--- a/frontend/src/app/modules/interventions/list/table/table.component.ts
+++ b/frontend/src/app/modules/interventions/list/table/table.component.ts
@@ -1,13 +1,13 @@
 import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
 import { MatPaginator, MatSort, MatTable } from '@angular/material';
+import { tap, startWith, switchMap, map } from 'rxjs/operators';
+import { combineLatest, Subscription } from 'rxjs';
 
+import { ComponentWithSubscriptions } from '@shared/components/base';
 import { Intervention, SortDirection, InterventionsFilter } from '@shared/domain/intervention.model';
 import { InterventionsDatasource } from './interventions.datasource';
 import { InterventionsService } from '../../interventions.service';
-import { tap, startWith, switchMap, map } from 'rxjs/operators';
-import { combineLatest } from 'rxjs';
-import { ComponentWithSubscriptions } from '@shared/components/base';
 import { EkoRoutePaths } from '../../../../eko-route-paths';
 
 @Component({
@@ -43,7 +43,7 @@ export class TableComponent extends ComponentWithSubscriptions implements AfterV
     this.subscriptions.add(this.subscribeToSortAndPageChanges());
   }
 
-  private subscribeToSortAndPageChanges() {
+  private subscribeToSortAndPageChanges(): Subscription {
     const sort$ = this.sort.sortChange.pipe(
       tap(() => (this.paginator.pageIndex = 0)),
       startWith({ active: 'date', direction: 'desc' }),
@@ -51,7 +51,7 @@ export class TableComponent extends ComponentWithSubscriptions implements AfterV
     const page$ = this.paginator.page.pipe(
       startWith({
         length: 100,
-        pageIndex: 1,
+        pageIndex: 0,
         pageSize: 10,
       }),
     );
@@ -61,7 +61,7 @@ export class TableComponent extends ComponentWithSubscriptions implements AfterV
       sortDirection: sort.direction === 'asc' ? SortDirection.Ascending : SortDirection.Descending,
     });
 
-    combineLatest([sort$, page$])
+    return combineLatest([sort$, page$])
       .pipe(
         map(toFilters),
         switchMap(filters => this.dataSource.loadInterventions$(filters)),

--- a/frontend/src/app/shared/domain/intervention.model.ts
+++ b/frontend/src/app/shared/domain/intervention.model.ts
@@ -1,5 +1,10 @@
 import { InterventionStatus } from '@shared/domain/intervention.status';
 
+export enum SortDirection {
+  Ascending,
+  Descending,
+}
+
 export interface InterventionFormData {
   id: string;
   /** Date in Date().toISOString() format */
@@ -45,4 +50,8 @@ export interface ListIntervention extends Intervention {
 
 export interface InterventionsFilter {
   status?: InterventionStatus;
+  page?: number;
+  pageSize?: number;
+  sortBy?: string;
+  sortDirection?: SortDirection;
 }


### PR DESCRIPTION
Please, take a look. There are some things missing:
- we need total number of results from the API, without it pagination won't work
- sorting works only for date
- no filtering - it seems the most useful filtering would be one by name of the person or description and API allows currently only by: status, city and street
- loader - `app-loader` doesn't work with datasource.loading$ observable. Should we somehow adjust it?