### PR TITLE
Feat/use incremental counter for intervention ids

### DIFF
--- a/backend/EkoFunkcje/EkoFunkcje/Features/Interventions/Models/InterventionCountEntity.cs
+++ b/backend/EkoFunkcje/EkoFunkcje/Features/Interventions/Models/InterventionCountEntity.cs
@@ -1,0 +1,16 @@
+using Microsoft.WindowsAzure.Storage.Table;
+
+namespace EkoFunkcje.Interventions.Models
+{
+    public class InterventionCountEntity : TableEntity {
+            public static string CountKey = "Count";
+
+            public InterventionCountEntity() {
+                this.PartitionKey = CountKey;
+                this.RowKey = CountKey;
+                this.Count = 1;
+            }
+               
+            public int Count { get; set; }
+    }
+}

--- a/backend/EkoFunkcje/EkoFunkcje/Features/Interventions/Utils/InterventionCounter.cs
+++ b/backend/EkoFunkcje/EkoFunkcje/Features/Interventions/Utils/InterventionCounter.cs
@@ -1,0 +1,38 @@
+using EkoFunkcje.Interventions.Models;
+using Microsoft.WindowsAzure.Storage.Table;
+using System.Threading.Tasks;
+
+
+namespace EkoFunkcje.Interventions.Utils {
+    public static class InterventionCounter {
+        public static async Task<int> GetNextId(CloudTable interventionsTable)
+        {
+            InterventionCountEntity counter = await GetCountEntity(interventionsTable);
+            (int nextCount, TableOperation operation) = GetNextCount(counter);
+
+            await interventionsTable.ExecuteAsync(operation);
+            
+            return nextCount;
+        }
+
+        private static async Task<InterventionCountEntity> GetCountEntity(CloudTable interventionsTable)
+        {
+            TableOperation getCountEntity = TableOperation.Retrieve<InterventionCountEntity>(
+                InterventionCountEntity.CountKey, InterventionCountEntity.CountKey
+            );
+            TableResult result = await interventionsTable.ExecuteAsync(getCountEntity);
+            return (InterventionCountEntity)result.Result;
+        }
+
+        private static (int, TableOperation) GetNextCount(InterventionCountEntity counter)
+        {
+            if (counter == null) {
+                var newCounter = new InterventionCountEntity();
+                return (newCounter.Count, TableOperation.Insert(newCounter));
+            }
+            else {
+                return (++counter.Count, TableOperation.Replace(counter));
+            }
+        }
+    }
+}

--- a/backend/EkoFunkcje/EkoFunkcje/Models/InterventionEntity.cs
+++ b/backend/EkoFunkcje/EkoFunkcje/Models/InterventionEntity.cs
@@ -48,7 +48,10 @@ namespace EkoFunkcje.Models
             set
             {
                 _commentsJson = value;
-                _commentsCollection = JsonConvert.DeserializeObject<ICollection<CommentDto>>(value);
+                _commentsCollection = 
+                    value == null ? 
+                        new List<CommentDto>() : 
+                        JsonConvert.DeserializeObject<ICollection<CommentDto>>(value);
             }
         }
 

--- a/backend/EkoFunkcje/EkoFunkcje/Models/InterventionEntity.cs
+++ b/backend/EkoFunkcje/EkoFunkcje/Models/InterventionEntity.cs
@@ -11,7 +11,6 @@ namespace EkoFunkcje.Models
     {
         public InterventionEntity()
         {
-            this.RowKey = Guid.NewGuid().ToString();
             this._commentsCollection = new List<CommentDto>();
         }
 

--- a/backend/EkoFunkcje/EkoFunkcje/Utils/InterventionFilterBuilder.cs
+++ b/backend/EkoFunkcje/EkoFunkcje/Utils/InterventionFilterBuilder.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using EkoFunkcje.Models.Requests;
+using EkoFunkcje.Interventions.Models;
 using Microsoft.WindowsAzure.Storage.Table;
 
 namespace EkoFunkcje.Utils
@@ -47,7 +48,15 @@ namespace EkoFunkcje.Utils
 
         public static string GetInterventionListViewFilter(ListInterventionsFilterRequest filter)
         {
-            List<string> filters = new List<string>();
+            string excludeCountEntityFilter = TableQuery.GenerateFilterCondition(
+                InterventionFieldNames.PartitionKey, 
+                QueryComparisons.NotEqual,
+                InterventionCountEntity.CountKey
+            );
+            
+            List<string> filters = new List<string>() {
+                excludeCountEntityFilter
+            };
             if (!string.IsNullOrWhiteSpace(filter.City))
             {
                 string cityFilter = TableQuery.GenerateFilterCondition(


### PR DESCRIPTION
Ten PR to moja propozycja zastąpienia obecnych GUID id zwykłym auto-powiększającym się Id opartym na liczbach całkowitych. 

Rozwiązanie to pozwoli niesamowicie poprawić User Experience i ułatwi inspektorom EkoStraży linkowanie/rozmawianie o interwencjach. GUIDy są praktycznie niemożliwe do zapamiętania i trudne do przekazania w formie ustnej, zapisania na kartce itp :)

Dodaje:
- Model entity "InterventionCount" - jeden wpis do tabeli Interwencji, który trzyma obecną liczbę wszystkich interwencji
- Statyczną klasę InterventionCounter odpowiedzialną za uzyskiwanie nowego Id dla tworzonej interwencji
- Zmienia logikę AddIntervention pod kątem stosowania powyższych klas

Dodatkowo:
- Naprawia buga przy Edytowaniu interwencji gdy brakuje komentarzy